### PR TITLE
fix: fix vercel.json

### DIFF
--- a/server/vercel.json
+++ b/server/vercel.json
@@ -2,14 +2,14 @@
   "version": 2,
   "builds": [
     {
-      "src": "*.js",
+      "src": "_dist/server.js",
       "use": "@vercel/node"
     }
   ],
   "routes": [
     {
       "src": "/(.*)",
-      "dest": "/"
+      "dest": "_dist/server.js"
     }
   ]
 }


### PR DESCRIPTION
Fix `vercel.json` because the production api site is `NOT FOUND`